### PR TITLE
Adds l_all/1

### DIFF
--- a/src/ktn_user_default.erl
+++ b/src/ktn_user_default.erl
@@ -1,7 +1,16 @@
 -module(ktn_user_default).
 -export([
          xref/0
+         ,l_all/1
         ]).
 
 xref() ->
     xref:d("ebin").
+
+l_all(Mods) when is_list(Mods) ->
+  lists:foldl(fun(Mod, A) ->
+                  Ret=[{Mod, shell_default:l(Mod)}],
+                  lists:append(A, Ret)
+              end, [], Mods);
+l_all(Mod) ->
+  l_all([Mod]).


### PR DESCRIPTION
I don't know about you, but I've accidentally purged running code when reloading a bunch of modules by loading a module twice in quick succession on more than one occasion. To prevent this, I created l_all/1. It behaves like shell_default:l/1, but also accepts an array of module atoms. It returns [{module_1_atom, l_1_return}, ... ].

There's also an overload that accepts a single atom. It wraps that atom in a list and passes it to l_all/1.